### PR TITLE
Update nloge.opam to dune 3.7

### DIFF
--- a/nloge.opam
+++ b/nloge.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/Nymphium/nloge"
 bug-reports: "https://github.com/Nymphium/nloge/issues"
 dev-repo: "git+https://github.com/Nymphium/nloge.git"
 depends: [
-  "dune" {>= "3.0.0"}
+  "dune" {>= "3.7.0"}
   "eio"
   "ppx_deriving"
   "yojson"


### PR DESCRIPTION
This matches the dune-project file in this repository.

Fixes linter warning from https://github.com/ocaml/opam-repository/pull/23755